### PR TITLE
Update contract-wall-src-prop.h

### DIFF
--- a/qlat/qlat/include/qlat/contract-wall-src-prop.h
+++ b/qlat/qlat/include/qlat/contract-wall-src-prop.h
@@ -13,7 +13,7 @@ inline double get_fsel_prob(const FieldSelection& fsel)
   const Long total_volume = geo.total_volume();
   Long n_elems = fsel.n_elems;
   glb_sum(n_elems);
-  return n_elems / total_volume;
+  return static_cast<double>(n_elems) / total_volume;
 }
 
 struct WallSrcProps {


### PR DESCRIPTION
Fixed a bug in get_fsel_prob(fsel) by adding a static_cast<double> to make it work as expected.